### PR TITLE
New Feature: disable tool swap on attack

### DIFF
--- a/src/main/kotlin/de/rubixdev/inventorio/client/configscreen/PlayerSettingsScreen.kt
+++ b/src/main/kotlin/de/rubixdev/inventorio/client/configscreen/PlayerSettingsScreen.kt
@@ -34,6 +34,7 @@ object PlayerSettingsScreen {
         addEnumEntry(category, entryBuilder, PlayerSettings.scrollWheelUtilityBelt, requireRestart = false, blocked = false, ScrollWheelUtilityBeltMode::class.java, ScrollWheelUtilityBeltMode.OFF)
         addBoolEntry(category, entryBuilder, PlayerSettings.skipEmptyUtilitySlots, requireRestart = false, blocked = false)
         addBoolEntry(category, entryBuilder, PlayerSettings.useItemAppliesToOffhand, requireRestart = false, blocked = false)
+        addBoolEntry(category, entryBuilder, PlayerSettings.disableAttackSwap, requireRestart = false, blocked = false)
         addBoolEntry(category, entryBuilder, PlayerSettings.canThrowUnloyalTrident, requireRestart = false, blocked = false)
         addBoolEntry(category, entryBuilder, PlayerSettings.darkTheme, requireRestart = false, blocked = false)
         addBoolEntry(category, entryBuilder, PlayerSettings.aggressiveButtonRemoval, requireRestart = false, blocked = false)

--- a/src/main/kotlin/de/rubixdev/inventorio/config/PlayerSettings.kt
+++ b/src/main/kotlin/de/rubixdev/inventorio/config/PlayerSettings.kt
@@ -55,6 +55,14 @@ object PlayerSettings : AbstractSettings() {
     )
 
     @JvmField
+    val disableAttackSwap = SettingsEntryBoolean(
+        false,
+        "DisableAttackSwap",
+        "inventorio.settings.player.disable_attack_swap",
+        "inventorio.settings.player.disable_attack_swap.tooltip",
+    )
+
+    @JvmField
     val canThrowUnloyalTrident = SettingsEntryBoolean(
         false,
         "CanThrowUnloyalTrident",
@@ -109,6 +117,7 @@ object PlayerSettings : AbstractSettings() {
             canThrowUnloyalTrident,
             darkTheme,
             useItemAppliesToOffhand,
+            disableAttackSwap,
             skipEmptyUtilitySlots,
             swappedHands,
             aggressiveButtonRemoval,

--- a/src/main/kotlin/de/rubixdev/inventorio/player/inventory/PlayerInventoryExtraStuff.kt
+++ b/src/main/kotlin/de/rubixdev/inventorio/player/inventory/PlayerInventoryExtraStuff.kt
@@ -3,6 +3,7 @@ package de.rubixdev.inventorio.player.inventory
 import de.rubixdev.inventorio.mixin.client.accessor.MinecraftClientAccessor
 import de.rubixdev.inventorio.packet.InventorioNetworking
 import de.rubixdev.inventorio.util.getLevelOn
+import de.rubixdev.inventorio.config.PlayerSettings.disableAttackSwap
 import kotlin.math.max
 import net.minecraft.block.BlockState
 import net.minecraft.client.MinecraftClient
@@ -13,6 +14,7 @@ import net.minecraft.entity.projectile.FireworkRocketEntity
 import net.minecraft.item.FireworkRocketItem
 import net.minecraft.item.ItemStack
 import net.minecraft.item.Items
+import net.minecraft.item.SwordItem
 import net.minecraft.item.ToolItem
 
 //#if MC >= 12002
@@ -39,8 +41,8 @@ abstract class PlayerInventoryExtraStuff protected constructor(player: PlayerEnt
 
     private fun getMostPreferredTool(block: BlockState): ItemStack {
         // TODO: some mods will disagree with justifying the most preferred tool by just speed
-        // If a player tries to dig with a selected tool, respect that tool and don't change anything
-        if (getActualMainHandItem().item is ToolItem || findFittingToolBeltIndex(getActualMainHandItem()) != -1) {
+        // If a player tries to dig with a selected tool, respect that tool and don't change anything unless the player has disabled combat swap and the tool was a sword
+        if (!(getActualMainHandItem().item is SwordItem && disableAttackSwap.boolValue) && (getActualMainHandItem().item is ToolItem || findFittingToolBeltIndex(getActualMainHandItem()) != -1)) {
             return getActualMainHandItem()
         }
         // Try to find the fastest tool on the tool belt to mine this block
@@ -60,8 +62,8 @@ abstract class PlayerInventoryExtraStuff protected constructor(player: PlayerEnt
     }
 
     private fun playerAttackConditions(): Boolean {
-        // if a player tries to attack with a tool, respect that tool and don't change anything
-        if (getActualMainHandItem().item is ToolItem || findFittingToolBeltIndex(getActualMainHandItem()) != -1) {
+        // if a player tries to attack with a tool or combat swap has been disabled, don't change anything
+        if (disableAttackSwap.boolValue || getActualMainHandItem().item is ToolItem || findFittingToolBeltIndex(getActualMainHandItem()) != -1) {
             return false
         }
         // if the attack is done through a Pickarang (from Quark), do nothing

--- a/src/main/resources/assets/inventorio/lang/de_de.yml
+++ b/src/main/resources/assets/inventorio/lang/de_de.yml
@@ -33,6 +33,11 @@ inventorio:
         Standardmäßig deaktiviert aufgrund der Tastenbindung "Utensilie verwenden".
         Nicht gegenseitig ausschließend mit der Tastenbindung "Utensilie verwenden".
 
+      disable_attack_swap: Attack Swap deaktivieren
+      disable_attack_swap.tooltip: |-
+        Wechsle beim Angriff nicht zu den Waffen im Werkzeuggürtel. 
+        Ermöglicht auch die Verwendung von Werkzeugen im Werkzeuggürtel beim Halten eines Schwertes. 
+
       aggressive_button_removal: Aggressive Schaltflächenentfernung
       aggressive_button_removal.tooltip: |-
         Einige Mods können einen Weg finden den Inventorio-Bildschirm zu modifizieren.

--- a/src/main/resources/assets/inventorio/lang/en_us.yml
+++ b/src/main/resources/assets/inventorio/lang/en_us.yml
@@ -33,6 +33,11 @@ inventorio:
         Disabled by default due to "Use Utility" button.
         Not mutually exclusive with "Use Utility" keybinding.
 
+      disable_attack_swap: Disable Attack Swap
+      disable_attack_swap.tooltip: |-
+        Do not swap to weapons in the Tool Belt when attacking mobs.
+        Also allows tools in the Tool Belt to be used when holding a sword.  
+
       aggressive_button_removal: Aggressive Button Removal
       aggressive_button_removal.tooltip: |-
         Some mods may find their way to modify Inventorio Screen.

--- a/src/main/resources/assets/inventorio/lang/fr_fr.yml
+++ b/src/main/resources/assets/inventorio/lang/fr_fr.yml
@@ -33,6 +33,11 @@ inventorio:
         Désactivé par défaut a cause du bouton "Utiliser avec la main secondaire".
         N'est pas mutuellement exclusif avec la touche pour "Utiliser avec la main secondaire".
 
+      disable_attack_swap: Désactiver l'échange d'attaque
+      disable_attack_swap.tooltip: |-
+        Ne changez pas d'arme dans la ceinture à outils lorsque vous attaquez. 
+        Permet également d'utiliser les outils de la ceinture à outils lors de la tenue d'une épée. 
+
       aggressive_button_removal: Forcer a retirer les boutons d'inventaire
       aggressive_button_removal.tooltip: |-
         Certains mods peuvent trouver un moyen d'ajouter leurs boutons

--- a/src/main/resources/assets/inventorio/lang/pt_br.yml
+++ b/src/main/resources/assets/inventorio/lang/pt_br.yml
@@ -33,6 +33,11 @@ inventorio:
         Desabilitado por padrão por causa do botão "Usar utilidade".
         Não é multuamente exclusive com o atalho de teclado do "Usar utilidade".
 
+      disable_attack_swap: Desativar troca de ataque
+      disable_attack_swap.tooltip: |-
+        Não troque por armas no Cinto de Ferramentas ao atacar. 
+        Também permite que as ferramentas do Cinto de Ferramentas sejam usadas ao segurar uma espada. 
+
       aggressive_button_removal: Remoção agressiva do botão
       aggressive_button_removal.tooltip: |-
         Alguns mods conseguem chegar a modificar a tela do Inventorio.


### PR DESCRIPTION
Added a new config option to disable swapping to a tool when attacking an entity.
Feedback is appreciated - this is my first time editing a Forge mod like this.
(By the way, I am @Apollonir on discord)